### PR TITLE
Use 0 instead of groot for compatibility with GNU Octave

### DIFF
--- a/CSI_Coherent/API_CSI_MUSIC_Visualize.m
+++ b/CSI_Coherent/API_CSI_MUSIC_Visualize.m
@@ -159,7 +159,7 @@ if PLOT_MUSIC_TOF
        num2str(direct_path_tof) ' [ns]) ']);
 
    %% 在MUSIC伪谱中标记直射径
-    set(groot,'CurrentFigure',hMUSIC);hold on;
+    set(0,'CurrentFigure',hMUSIC);hold on;
     x_aoa = direct_path_aoa;
     y_tof = direct_path_tof;
     z_dB = Pmusic(direct_path_aoa_index,direct_path_tof_index);

--- a/CSI_NonCoherent/API_CSI_MUSIC_Visualize.m
+++ b/CSI_NonCoherent/API_CSI_MUSIC_Visualize.m
@@ -136,7 +136,7 @@ if PLOT_MUSIC_TOF
            num2str(direct_path_tof) ' [ns]) ']);
 
        %% 在MUSIC伪谱中标记直射径
-        set(groot,'CurrentFigure',hMUSIC);hold on;
+        set(0,'CurrentFigure',hMUSIC);hold on;
         x_aoa = direct_path_aoa;
         y_tof = direct_path_tof;
         z_dB = Pmusic(direct_path_aoa_index,direct_path_tof_index);


### PR DESCRIPTION
GNU Octave doesn't have built-in `groot`.
Instead, both MATLAB and GNU Octave can perform `set(0, 'CurrentFigure', <figure_handler>)`